### PR TITLE
Do not replicate two_year_recid field

### DIFF
--- a/truth_tables.py
+++ b/truth_tables.py
@@ -177,6 +177,7 @@ def is_race(race):
 
 
 def write_two_year_file(f, pop, test, headers):
+    headers = list(headers)
     headers.append('two_year_recid')
     with open(f, 'w') as o:
         writer = DictWriter(o, fieldnames=headers)


### PR DESCRIPTION
I assume you don't want the second file, compas-scores-two-years.csv, to contain
the column two_year_recid twice, right?