### PR TITLE
substitute comma of decimal values with dot

### DIFF
--- a/truth_tables.py
+++ b/truth_tables.py
@@ -193,6 +193,10 @@ def write_two_year_file(f, pop, test, headers):
                 row['c_charge_degree'] = 'F'
             else:
                 row['c_charge_degree'] = 'M'
+
+            # replace commas in decimal values to avoid parsing confusion
+            row =  { k: str(row[k]).replace(",", ".") for k in row }
+
             writer.writerow(row)
             stdout.write('.')
 


### PR DESCRIPTION
This was a problem for my parser during processing the data; it might be for others
as well. Substituting commas of decimal values with dots is probably a good idea
for a csv!